### PR TITLE
Upgrade Redocly to v2

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,6 @@
   </head>
   <body>
     <redoc spec-url='https://api.opendota.com/api'></redoc>
-    <script src="https://rebilly.github.io/ReDoc/releases/v1.16.0/redoc.min.js"> </script>
+    <script src="https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
Redocly v2 supports OpenApi 3, while earlier releases do not.

https://github.com/Redocly/redoc